### PR TITLE
fix: undefined variables and wrong names

### DIFF
--- a/sources/Experience/Experience.js
+++ b/sources/Experience/Experience.js
@@ -96,7 +96,7 @@ export default class Experience
 
     setRenderer()
     {
-        this.renderer = new Renderer({ rendererInstance: this.rendererInstance })
+        this.renderer = new Renderer()
 
         this.targetElement.appendChild(this.renderer.instance.domElement)
     }

--- a/sources/Experience/Utils/Loader.js
+++ b/sources/Experience/Utils/Loader.js
@@ -5,7 +5,7 @@ import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js'
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js'
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js'
 
-export default class Resources extends EventEmitter
+export default class Loader extends EventEmitter
 {
     /**
      * Constructor
@@ -65,7 +65,7 @@ export default class Resources extends EventEmitter
                 {
                     this.fileLoadEnd(_resource, _data)
 
-                    DRACOLoader.releaseDecoderModule()
+                    dracoLoader.dispose()
                 })
             }
         })


### PR DESCRIPTION
There are some mistakes in the template:

1. inside `Experience.js`, there is no `rendererInstance` attribute in the class, so it's passing `undefined` to the `Render()`.
2. inside `Loader.js`, the class name is wrong.
3. There is no `DracoLoader.releaseDecoderModule()` method in this version, it became an instance method `dispose()` instead.

None of these mistakes will have an impact on the final result, but it's always good to fix them :)